### PR TITLE
Adds username, password, port-number as variable and start via systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Publish Logitech Media Server (LMS) status changes such as "song started playing
 * copy `lms2mqtt.py`to a directory of your choice, mine is in `/home/admin/daemons/lms2mqtt`
 * configure the name of the machine running the LMS server in `lms2mqtt.py`
 * configure the name of the machine running the MQTT broker in `lms2mqtt.py`
+* configure the portnumber of the MQTT broker in `lms2mqtt.py`
 * configure the username for the MQTT broker in `lms2mqtt.py`
 * configure the password for the MQTT broker in `lms2mqtt.py`
 * if no username or password is used comment out line 149: `mqttclient.username_pw_set(MQTT_USER, MQTT_PASSWD)` in `lms2mqtt.py`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ WantedBy=multi-user.target
 ```
 * change `<user>` to the user you are using in this case: `admin`
 * change `<path-to-lms2mqtt>` to the directory where your `lms2mqtt.py` is, in this case: `daemons/lms2mqtt`
+* as root or using sudo reload systemd: `sudo systemctl daemon-reload`
+* then start lms2mqtt: `sudo systemctl start lms2mqtt.service`
+* then make it start at boot: `sudo systemctl enable lms2mqtt.service`
 <br/>
 
 * when using init.d:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,32 @@ Publish Logitech Media Server (LMS) status changes such as "song started playing
 * copy `lms2mqtt.py`to a directory of your choice, mine is in `/home/admin/daemons/lms2mqtt`
 * configure the name of the machine running the LMS server in `lms2mqtt.py`
 * configure the name of the machine running the MQTT broker in `lms2mqtt.py`
+* configure the username for the MQTT broker in `lms2mqtt.py`
+* configure the password for the MQTT broker in `lms2mqtt.py`
+* if no username or password is used comment out line 149: `mqttclient.username_pw_set(MQTT_USER, MQTT_PASSWD)` in `lms2mqtt.py`
+<br/>
+
+* when using systemd:
+* as root or using sudo: create a file `/etc/systemd/system/lms2mqtt.service` and insert:
+```
+[Unit]
+Description=MQTT for the Logitech Media Server
+After=multi-user.target
+
+[Service]
+WorkingDirectory=/home/<user>/
+User=<user>
+ExecStart=/usr/bin/python3 /home/<user>/<path-to-lms2mqtt>/lms2mqtt.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+```
+* change `<user>` to the user you are using in this case: `admin`
+* change `<path-to-lms2mqtt>` to the directory where your `lms2mqtt.py` is, in this case: `daemons/lms2mqtt`
+<br/>
+
+* when using init.d:
 * copy file `bw-lms2mqtt` to `/etc/init.d/` and make it executable
 * in `bw-lms2mqtt`, set the path where you stored the `lms2mqtt.py` script 
 * activate the service with `sudo update-rc.d bw-lms2mqtt defaults`

--- a/lms2mqtt.py
+++ b/lms2mqtt.py
@@ -45,8 +45,11 @@ logger.addHandler(handlerConsole)
 LMS_HOST = "media-server"
 
 #----- MQTT constants
-MQTT_BROKER = "ha-server"
-MQTT_PUB_BASE_LMS = "lms/"
+MQTT_BROKER = "ha-server"    # Change this to your MQTT server-IP or server-name
+MQTT_PORT = 1883             # Change this to your MQTT serverport. Normally 1883
+MQTT_PUB_BASE_LMS = "lms/"   # This is what your messages in MQTT start with
+MQTT_USER = "username"       # If you use a username and password change this to your username, else comment out: "mqttclient.username_pw_set(MQTT_USER, MQTT_PASSWD)" at approx. line 149
+MQTT_PASSWD = "password"     # If you use a username and password change this to your password, else comment out: "mqttclient.username_pw_set(MQTT_USER, MQTT_PASSWD)" at approx. line 149
 
 #----- try to read from /etc/default
 DEFAULT_BW="/etc/default/bw"
@@ -143,7 +146,8 @@ signal.signal(signal.SIGTERM, signal_handler)
 mqttClient = mqtt.Client(client_id=LMS_LOGNAME)
 mqttClient.on_connect = on_connect
 mqttClient.on_message = on_message
-mqttClient.connect(MQTT_BROKER, 1883, 60)
+mqttclient.username_pw_set(MQTT_USER, MQTT_PASSWD)    # Comment out this line if your not using a username and password for your MQTT-broker
+mqttClient.connect(MQTT_BROKER, MQTT_PORT, 60)
 mqttClient.loop_start()
 
 # ----- setup Telnet connection to LMS --------------------------------

--- a/lms2mqtt.py
+++ b/lms2mqtt.py
@@ -146,7 +146,7 @@ signal.signal(signal.SIGTERM, signal_handler)
 mqttClient = mqtt.Client(client_id=LMS_LOGNAME)
 mqttClient.on_connect = on_connect
 mqttClient.on_message = on_message
-mqttclient.username_pw_set(MQTT_USER, MQTT_PASSWD)    # Comment out this line if your not using a username and password for your MQTT-broker
+mqttClient.username_pw_set(MQTT_USER, MQTT_PASSWD)    # Comment out this line if your not using a username and password for your MQTT-broker
 mqttClient.connect(MQTT_BROKER, MQTT_PORT, 60)
 mqttClient.loop_start()
 


### PR DESCRIPTION
Added to lms2mqtt.py with comments and added to the README.md.

For me the bw-lms2mqtt for init.d is broken so I used systemd on my debian bookworm server.


h3n3